### PR TITLE
Add globalResponses configuration

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -26,4 +26,4 @@ function configure(newConfig: Partial<Config>) {
 
 const getConfig = (): Config => ({ ...config })
 
-export { configure, getConfig, Config, mount }
+export { configure, getConfig, mount }

--- a/src/models.ts
+++ b/src/models.ts
@@ -72,6 +72,7 @@ export interface Config {
   mount: Mount
   extend: Extensions
   changeRoute: (path: string) => void
+  defaultResponses?: Array<WrapResponse>
   history?: BrowserHistory
   portal?: string
   handleQueryParams?: boolean

--- a/src/wrap.tsx
+++ b/src/wrap.tsx
@@ -113,7 +113,7 @@ const debugRequests = () => {
 }
 
 const getMount = () => {
-  const { portal, changeRoute, history, mount } = getConfig()
+  const { portal, changeRoute, history, mount, defaultResponses } = getConfig()
   const { Component, props, responses, path, hasPath, debug, historyState } =
     getOptions()
 
@@ -137,7 +137,12 @@ const getMount = () => {
     changeRoute(path)
   }
 
-  mockNetwork(responses, debug)
+  let mockedResponses: Response[] = [...responses]
+  if (defaultResponses) {
+    mockedResponses = [...mockedResponses, ...defaultResponses]
+  }
+
+  mockNetwork(mockedResponses, debug)
 
   return mount(<C {...props} />)
 }

--- a/tests/components.mock.jsx
+++ b/tests/components.mock.jsx
@@ -347,3 +347,35 @@ export const GreetingComponent = () => {
 
   return <div>Hi {name}!</div>
 }
+
+export const MyComponentWithFeatureFlags = () => {
+  const [flags, setFlags] = useState([])
+
+  useEffect(() => {
+    const retrieveFeatureFlags = async () => {
+      try {
+        const request = new Request('my-host/feature-flags')
+        const response = await fetch(request)
+        if (!response) return
+        const { flags } = await response.json()
+
+        setFlags(flags)
+      } catch (e) {
+        setFlags([])
+      }
+    }
+
+    retrieveFeatureFlags()
+  }, [])
+
+  return (
+    <>
+      <h1>Feature flags test</h1>
+      {flags.includes('my-flag') && (
+        <div>
+          <span>Feature Flag enabled</span>
+        </div>
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
## :tophat: What?
<!--- Describe your changes in detail -->
Add `defaultResponses` option to `wrapito-vitest`.

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are cases when you need a set of responses to be common for all components, e.g Feature Flags(FF).
Historically, the way to do this is by defining an extension and then using it with every call to `wrap`.
```js
// setupTests.js
import { render } from '@testing-library/react';
import { configure } from 'wrapito-vitest';

configure({
    mount: render,
    extend: {
        withMissingProductsResponses: ({ addResponses }, [otherResponses = []]) => {
          addResponses([
            {
              path: '/feature-flags',
              responseBody: {
                next_page: null,
                results: ['flag-1', 'flag-2'],
              },
            },
          ])
        },
    }
})

// app.test.js
import { wrap } from 'wrapito-vitest';
import { screen } from '@testing-library/react';

import App from './App'

test('should render app', () => {
    wrap(App).withDefaultResponses().mount();

    expect(await screen.findByText('Hello, world!')).toBeVisible();
})
```

We can do better if we could define a set of default responses that every component should use.
```js
// setupTests.js
import { render } from '@testing-library/react';
import { configure } from 'wrapito-vitest';

configure({
    mount: render,
    defaultResponses: [
        {
          path: '/feature-flags',
          responseBody: {
            next_page: null,
            results: ['flag-1', 'flag-2'],
          },
        },
    ]
})

// app.test.js
import { wrap } from 'wrapito-vitest';
import { screen } from '@testing-library/react';

import App from './App'

test('should render app', () => {
    wrap(App).mount(); // Notice the absence of the extension

    expect(await screen.findByText('Hello, world!')).toBeVisible();
})
```

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->
Unit tested
