### PR TITLE
FIX: Print all diffs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
-        "jest-diff": "^29.7.0",
         "deep-equal": "^2.2.3",
+        "jest-diff": "^29.7.0",
         "object-hash": "^3.0.0",
         "rimraf": "^5.0.5",
         "whatwg-fetch": "^3.6.20"

--- a/src/matchers/messages.ts
+++ b/src/matchers/messages.ts
@@ -39,12 +39,13 @@ const bodyDoesNotMatchErrorMessage = (
   expected: Body,
   received: Array<Body>,
 ) => {
-  const [r] = received
+  const diffs = received.map(r => diff(expected, r)).join('\n\n')
+
   return {
     pass: false,
     message: () =>
       `🌯 Wrapito: Fetch body does not match.
-${diff(expected, r)}`,
+${diffs}`,
   }
 }
 

--- a/src/matchers/messages.ts
+++ b/src/matchers/messages.ts
@@ -37,9 +37,11 @@ const methodDoesNotMatchErrorMessage = (
 
 const bodyDoesNotMatchErrorMessage = (
   expected: Body,
-  received: Array<Body>,
+  receivedBodies: Array<Body>,
 ) => {
-  const diffs = received.map(r => diff(expected, r)).join('\n\n')
+  const diffs = receivedBodies
+    .map(received => diff(expected, received))
+    .join('\n\n')
 
   return {
     pass: false,


### PR DESCRIPTION
## :camera_flash: Screenshots/Gif/Videos
<!--- Drag and drop your screenshot here -->

<!--- If you want to share the before and after images, use this table -->
<!---
Before | After
---|---
![before image]() | ![after image]()
 -->
![image](https://github.com/mercadona/wrapito-vitest/assets/8824202/502feccd-ca12-42d1-8e63-823433a601ae)


## :tophat: What?
<!--- Describe your changes in detail -->
If multiple bodies are received, print the diff between the expected object and all the bodies.

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To keep the behaviour that `wrapito` has.

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->

## :speaking_head: Comments
<!--- Is it necessary any context for this PR? -->
<!--- Do you have any clarification related to the code? -->
<!--- If you are iterating the PR, maybe you can tell us about it. For example: "Step 2/4" or "Take into account this PR #10" -->
