### PR TITLE
Automatically extend vitest with wrapito matchers

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,14 @@
   "version": "8.0.0",
   "description": "🌯 🌯 Wrap you tests so that you can test both behaviour and components with less effort.",
   "type": "module",
-  "exports": "./dist/index.js",
+  "exports": {
+    ".": {
+     "import": "./dist/index.js"
+    },
+    "./integration": {
+     "import": "./dist/integration.js"
+    }
+  },
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -1,0 +1,4 @@
+import { expect } from 'vitest'
+import { matchers } from '.'
+
+expect.extend(matchers)

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig(options => ({
-  entryPoints: ['src/index.ts'],
+  entryPoints: {
+    dist: './src/index.ts',
+    integration: './src/integration.ts',
+  },
   outDir: 'dist',
   format: ['esm'],
   tsconfig: './tsconfig.json',


### PR DESCRIPTION
## :tophat: What?
<!--- Describe your changes in detail -->
Automatically add `wrapito-vitest` matchers to `vitest`.

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Pure convenience, the older way still works.

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->
I test this locally using `secco` and our Vite boilerplate.

## 🗣️ Comments
Now when you install `wrapito-vitest` in your `setupTest.ts` you can do:
```ts
import 'wrapito-vitest/integration'
import { configure } from 'wrapito-vitest'

configure({}) // Normal configuration
```

And matchers will be added to `vitest`.
