### PR TITLE
Make wrapito agnostic of testing framework

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "redux": "^4.2.1",
         "redux-thunk": "^2.4.2",
         "rollup": "^4.9.1",
+        "tinyspy": "^2.2.1",
         "tsup": "^8.0.1",
         "typescript": "^5.3.3",
         "vitest": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
   "homepage": "https://github.com/mercadona/wrapito-vitest#readme",
   "dependencies": {
     "chalk": "^5.3.0",
-    "jest-diff": "^29.7.0",
     "deep-equal": "^2.2.3",
+    "jest-diff": "^29.7.0",
     "object-hash": "^3.0.0",
     "rimraf": "^5.0.5",
     "whatwg-fetch": "^3.6.20"
@@ -75,6 +75,7 @@
     "redux": "^4.2.1",
     "redux-thunk": "^2.4.2",
     "rollup": "^4.9.1",
+    "tinyspy": "^2.2.1",
     "tsup": "^8.0.1",
     "typescript": "^5.3.3",
     "vitest": "^1.1.0"

--- a/src/mockNetwork.ts
+++ b/src/mockNetwork.ts
@@ -1,21 +1,20 @@
 import chalk from 'chalk'
 import type { Response, WrapRequest } from './models'
 import { getRequestMatcher } from './requestMatcher'
-import { vi } from 'vitest'
-import type { Mock } from 'vitest'
+import { SpyFn, spy } from 'tinyspy'
 
 declare global {
   interface Window {
-    fetch: Mock
+    fetch: SpyFn
   }
 }
 
 beforeEach(() => {
-  global.window.fetch = vi.fn()
+  global.window.fetch = spy()
 })
 
 afterEach(() => {
-  global.window.fetch.mockRestore()
+  global.window.fetch.reset()
 })
 
 const createDefaultResponse = async () => {
@@ -96,14 +95,14 @@ const mockFetch = async (
 const mockNetwork = (responses: Response[] = [], debug: boolean = false) => {
   const fetch = global.window.fetch
 
-  fetch.mockImplementation((input: WrapRequest, init?: RequestInit) => {
+  fetch.impl = (input: WrapRequest, init?: RequestInit) => {
     if (typeof input === 'string') {
       const request = new Request(input, init)
       return mockFetch(responses, request, debug)
     }
     const request = input
     return mockFetch(responses, request, debug)
-  })
+  }
 }
 
 const printMultipleResponsesWarning = (response: Response) => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,7 +2,7 @@ import deepEqual from 'deep-equal'
 import { getConfig } from '../config'
 import { RequestOptions, WrapRequest } from '../models'
 
-import type { MockedFunction } from 'vitest'
+import { SpyFn } from 'tinyspy'
 
 const getDefaultHost = () => {
   const configuredHost = getConfig().defaultHost
@@ -23,8 +23,8 @@ export const findRequestsByPath = (
   expectedPath: string,
   options: RequestOptions = { method: 'GET' },
 ) => {
-  const typedFetch = fetch as MockedFunction<typeof fetch>
-  return typedFetch.mock.calls.filter(([call]) => {
+  const typedFetch = fetch as SpyFn
+  return typedFetch.calls.filter(([call]) => {
     const url = getUrl(call)
     const defaultHost = getDefaultHost()
     const callURL = new URL(url, defaultHost)

--- a/src/wrap.tsx
+++ b/src/wrap.tsx
@@ -10,16 +10,15 @@ import type {
   Extension,
   Extensions,
 } from './models'
-import { vi } from 'vitest'
-import type { MockedFunction } from 'vitest'
+import { SpyFn, spy } from 'tinyspy'
 
 beforeEach(() => {
-  global.fetch = vi.fn()
+  global.fetch = spy()
 })
 
 afterEach(() => {
-  const mockedFetch = global.fetch as MockedFunction<typeof fetch>
-  mockedFetch.mockRestore()
+  const mockedFetch = global.fetch as SpyFn
+  mockedFetch.reset()
 })
 
 const wrap = (component: unknown): Wrap => {

--- a/tests/matchers/toHaveBeenFetchedWith.test.ts
+++ b/tests/matchers/toHaveBeenFetchedWith.test.ts
@@ -76,7 +76,7 @@ describe('toHaveBeenFetchedWith', () => {
       await fetch(request)
 
       //@ts-ignore
-      fetch.mock.calls[0][0].json()
+      fetch.calls[0][0].json()
 
       const { message } = matchers.toHaveBeenFetchedWith(path, {
         body: {


### PR DESCRIPTION
## :tophat: What?
<!--- Describe your changes in detail -->
Make wrapito agnostic of testing framework, _i.e_ it will work with `jest` and `vitest`.

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
1. Because we don't want to maintain 2 separate libraries
2. We all could benefits from the improvements in `wrapito-vitest`

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->
All tests must pass

close 
