### PR TITLE
[Fixed]: Extension return type to void since extensions should not return any Wrap

### DIFF
--- a/src/models.ts
+++ b/src/models.ts
@@ -65,7 +65,7 @@ export interface WrapExtensionAPI {
   addResponses: (responses: Array<WrapResponse>) => unknown
 }
 
-type Extension = <T>(extensionAPI: WrapExtensionAPI, args: T) => Wrap
+type Extension = <T>(extensionAPI: WrapExtensionAPI, args: T) => void
 
 type Extensions = {
   [key: string]: Extension


### PR DESCRIPTION
…hing

## :camera_flash: Screenshots/Gif/Videos
<!--- Drag and drop your screenshot here -->

<!--- If you want to share the before and after images, use this table -->
<!---
Before | After
---|---
![before image]() | ![after image]()
 -->

## :tophat: What?
<!--- Describe your changes in detail -->
Extension return type to void since extensions should not return any Wrap

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We had to do weird cheats, like `: any` and `//ts-ignore` when typing setupTests

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->
Tested in mo.delivery.tempus

## :speaking_head: Comments
<!--- Is it necessary any context for this PR? -->
<!--- Do you have any clarification related to the code? -->
<!--- If you are iterating the PR, maybe you can tell us about it. For example: "Step 2/4" or "Take into account this PR #10" -->
