### PR TITLE
chore: wip add types for wrap

### DIFF
--- a/src/wrap.tsx
+++ b/src/wrap.tsx
@@ -3,12 +3,13 @@ import * as React from 'react'
 import { mockNetwork } from './mockNetwork'
 import { getConfig } from './config'
 import { updateOptions, getOptions } from './options'
-import type {
+import {
   Response,
   Wrap,
   WrapExtensionAPI,
   Extension,
   Extensions,
+  WrappedExtensions,
 } from './models'
 import { vi } from 'vitest'
 import type { MockedFunction } from 'vitest'
@@ -22,7 +23,7 @@ afterEach(() => {
   mockedFetch.mockRestore()
 })
 
-const wrap = (component: unknown): Wrap => {
+const wrap = (component: unknown) => {
   updateOptions({
     Component: component,
     responses: [],
@@ -35,7 +36,20 @@ const wrap = (component: unknown): Wrap => {
   return wrapWith()
 }
 
-const wrapWith = (): Wrap => {
+export const configWrap = <T extends Extensions>(component: unknown) => {
+  updateOptions({
+    Component: component,
+    responses: [],
+    props: {},
+    path: '',
+    hasPath: false,
+    debug: process.env.npm_config_debugRequests === 'true',
+  })
+
+  return wrapWith() as Wrap & WrappedExtensions<T>
+}
+
+const wrapWith = () => {
   const extensions = extendWith()
 
   return {

--- a/tests/lib/extend.test.ts
+++ b/tests/lib/extend.test.ts
@@ -1,13 +1,13 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { vi, it, expect } from 'vitest'
-import { wrap, configure } from '../../src/index'
+import { configure, typedConfig } from '../../src/index'
 
 import { MyComponentWithLogin } from '../components.mock'
 
 it('should extend wrapito', async () => {
   const otherCustomExtension = vi.fn()
   const customArgs = { foo: 'bar' }
-  configure({
+  const { wrap } = typedConfig({
     mount: render,
     extend: {
       withLogin: ({ addResponses }, username: string) =>
@@ -19,9 +19,15 @@ it('should extend wrapito', async () => {
             responseBody: username,
           },
         ]),
-      withOtherCustomExtension: () => otherCustomExtension(customArgs),
+      withOtherCustomExtension: ({}) => otherCustomExtension(customArgs),
     },
   })
+  wrap(MyComponentWithLogin)
+    .withNetwork()
+    .debugRequests()
+    .withOtherCustomExtension()
+    .withLogin('Fran Perea')
+    .mount()
   wrap(MyComponentWithLogin)
     .withLogin('Fran Perea')
     .withOtherCustomExtension()


### PR DESCRIPTION
## :camera_flash: Screenshots/Gif/Videos
<!--- Drag and drop your screenshot here -->

<!--- If you want to share the before and after images, use this table -->
<!---
Before | After
---|---
![before image]() | ![after image]()
 -->

## :tophat: What?
<!--- Describe your changes in detail -->

## :thinking: Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :test_tube: How has this been tested? / :boom: How will I know if this breaks?
<!--- What types of tests you are doing? -->
<!--- How do you know this is working properly? -->

## :speaking_head: Comments
<!--- Is it necessary any context for this PR? -->
<!--- Do you have any clarification related to the code? -->
<!--- If you are iterating the PR, maybe you can tell us about it. For example: "Step 2/4" or "Take into account this PR #10" -->
First attempt at adding types to wrap, with this method we can configure the wrap and export a typed wrap for our tests.

I added this "Omit<this, 'withNetwork'>" to avoid using multiple times the same build step, but couldn't find a way to add it to the custom extends

Right now you must pass an empty object as a parameter to any mocks, this should be fixed so we can have helpers without any params.

I used way too many "X as Y", the types should not be forced, would be ideal to make wrapito infer them to avoid magical things
